### PR TITLE
Allow specifying HTTP verbs to expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ plugins:
 ```yaml
 serverless-offline:
   urlLambdaFunctionsHttpPort: 3003
+
+  # Optional - choose which HTTP verb(s) to enable. If omitted, GET and POST will be enabled
+  urlLambdaFunctionsHttpVerbs:
+    - GET
+    - DELETE
 ```
 
-3. Configure a lambda url function. When you add the `url` option, the handler will expose it as a `GET/POST` HTTP endpoint(`/dev/ping`). The HTTP endpoint doesn't go through the API Gateway, which means that you can set your own `timeout` and it will respect it. Traditionally, the API Gateway would timeout after 30 seconds.
+3. Configure a lambda url function. When you add the `url` option, the handler will expose it as an HTTP endpoint(`/dev/ping`) with the verbs specified in `urlLambdaFunctionsHttpVerbs` or `GET` and `POST` if that setting is not specified. The HTTP endpoint doesn't go through the API Gateway, which means that you can set your own `timeout` and it will respect it. Traditionally, the API Gateway would timeout after 30 seconds.
 
 ```yaml
 ping:

--- a/index.js
+++ b/index.js
@@ -36,13 +36,23 @@ export default class ServerlessOfflineLambdaFunctionUrls {
   }
   getEvents(functions) {
     const stage = this.getStage()
+    const verbs = this.configuration?.custom?.['serverless-offline']?.urlLambdaFunctionsHttpVerbs ?? [
+      'GET',
+      'POST'
+    ]
     return Object.entries(functions).reduce((events, [functionKey, {handler}]) => {
       const path = `/${stage}/${encodeURIComponent(functionKey)}`
-      return [
-        ...events,
-        {functionKey, handler, http: {routeKey: `GET ${path}`, payload: '2.0', isHttpApi: true, path, method: 'GET'}},
-        {functionKey, handler, http: {routeKey: `POST ${path}`, payload: '2.0', isHttpApi: true, path, method: 'POST'}},
-      ]
+      return events.concat(verbs.map(v => ({
+        functionKey,
+        handler,
+        http: {
+          routeKey: `${verb} ${path}`,
+          payload: '2.0',
+          isHttpApi: true,
+          path,
+          method: verb
+        }
+      })))
     }, [])
   }
   getStage() {


### PR DESCRIPTION
I have a need for exposing a `PUT`-only function URL. This PR does a light refactor to make it possible to explicitly set the HTTP verbs for function urls.